### PR TITLE
feat(cards): deliver complete phase one card experience

### DIFF
--- a/e2e/phase0.spec.js
+++ b/e2e/phase0.spec.js
@@ -222,3 +222,54 @@ test('viewer sees the board but cannot mutate or drag its content', async ({ pag
   expect(updateRequests).toEqual([])
   await expect(page.getByTestId(`column-${backlogId}`).getByTestId(`card-${cardId}`)).toBeVisible()
 })
+
+test('owner can complete phase one card details', async ({ page }) => {
+  await login(page, 'owner@phase0.test')
+  await page.goto(`/boards/${boardId}`)
+  await page.getByTestId(`card-${cardId}`).click()
+
+  const priorityResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('combobox', { name: 'Priority' }).click()
+  await page.getByRole('option', { name: 'URGENT' }).click()
+  await priorityResponse
+
+  await page.getByLabel('Label name').fill('Release')
+  const labelResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('button', { name: 'Add label' }).click()
+  await labelResponse
+  await expect(page.getByText('Release')).toBeVisible()
+
+  await page.getByLabel('Checklist item').fill('Verify release')
+  const checklistResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('button', { name: 'Add checklist item' }).click()
+  await checklistResponse
+  await expect(page.getByText('Verify release')).toBeVisible()
+  const completeChecklistResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('checkbox').last().click()
+  await completeChecklistResponse
+
+  await page.getByLabel('Start date').fill('2030-01-01T09:00')
+  await page.getByLabel('Due date').fill('2030-01-02T09:00')
+  const datesResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('button', { name: 'Save dates' }).click()
+  await datesResponse
+
+  await page.keyboard.press('Escape')
+  await expect(page.getByTestId(`card-${cardId}`).getByText('Release')).toBeVisible()
+  await expect(page.getByTestId(`card-${cardId}`).getByText('1/1')).toBeVisible()
+})

--- a/e2e/phase0.spec.js
+++ b/e2e/phase0.spec.js
@@ -260,6 +260,21 @@ test('owner can complete phase one card details', async ({ page }) => {
   await page.getByRole('checkbox').last().click()
   await completeChecklistResponse
 
+  const watchResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('button', { name: 'Watch', exact: true }).click()
+  await watchResponse
+  await expect(page.getByRole('button', { name: 'Watching' })).toBeVisible()
+
+  const completedResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('checkbox', { name: 'Card completed' }).click()
+  await completedResponse
+
   await page.getByLabel('Start date').fill('2030-01-01T09:00')
   await page.getByLabel('Due date').fill('2030-01-02T09:00')
   const datesResponse = page.waitForResponse(
@@ -272,4 +287,130 @@ test('owner can complete phase one card details', async ({ page }) => {
   await page.keyboard.press('Escape')
   await expect(page.getByTestId(`card-${cardId}`).getByText('Release')).toBeVisible()
   await expect(page.getByTestId(`card-${cardId}`).getByText('1/1')).toBeVisible()
+})
+
+test('owner can edit, react to, and delete a phase one comment', async ({ page }) => {
+  await login(page, 'owner@phase0.test')
+  await page.goto(`/boards/${boardId}`)
+  await page.getByTestId(`card-${cardId}`).click()
+
+  const addResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByPlaceholder('Write a comment...').fill('Phase one comment')
+  await page.getByPlaceholder('Write a comment...').press('Enter')
+  await addResponse
+  await expect(page.getByText('Phase one comment')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Edit', exact: true }).click()
+  const editResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  const editInput = page.getByDisplayValue('Phase one comment')
+  await editInput.fill('Edited phase one comment')
+  await editInput.press('Enter')
+  await editResponse
+  await expect(page.getByText('Edited phase one comment')).toBeVisible()
+  await expect(page.getByText('(edited)')).toBeVisible()
+
+  const reactionResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('button', { name: '👍', exact: true }).click()
+  await reactionResponse
+  await expect(page.getByRole('button', { name: '👍 1' })).toBeVisible()
+
+  const deleteResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}`) &&
+      response.request().method() === 'PUT' && response.status() === 200
+  )
+  await page.getByRole('button', { name: 'Delete', exact: true }).click()
+  await deleteResponse
+  await expect(page.getByText('Edited phase one comment')).toHaveCount(0)
+})
+
+test('owner can copy, share, archive, and restore a phase one card', async ({
+  page,
+  context
+}) => {
+  await context.grantPermissions(
+    ['clipboard-read', 'clipboard-write'],
+    { origin: 'http://127.0.0.1:5173' }
+  )
+  await login(page, 'owner@phase0.test')
+  await page.goto(`/boards/${boardId}`)
+  await page.getByTestId(`card-${cardId}`).click()
+
+  await page.getByLabel('Target column').click()
+  await page.getByRole('option', { name: 'Done' }).click()
+  const copyResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}/copy`) &&
+      response.status() === 201
+  )
+  await page.getByText('Copy', { exact: true }).click()
+  await copyResponse
+  await expect(page.getByText('Drag me safely (copy)')).toBeVisible()
+
+  await page.getByText('Share', { exact: true }).click()
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(`http://127.0.0.1:5173/boards/${boardId}?cardId=${cardId}`)
+
+  const archiveResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}/archive`) &&
+      response.status() === 200
+  )
+  await page.getByTestId('archive-active-card').click()
+  await page.getByRole('button', { name: 'Confirm' }).click()
+  await archiveResponse
+  await expect(page.getByTestId(`card-${cardId}`)).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Archive', exact: true }).click()
+  await expect(page.getByText('Drag me safely', { exact: true })).toBeVisible()
+  const restoreResponse = page.waitForResponse(
+    (response) => response.url().endsWith(`/cards/${cardId}/archive`) &&
+      response.status() === 200
+  )
+  await page.getByRole('button', { name: 'Restore' }).click()
+  await restoreResponse
+  await expect(page.getByText('Drag me safely', { exact: true })).toHaveCount(0)
+})
+
+test('card assignment updates the recipient notification badge in real time', async ({
+  browser
+}) => {
+  const ownerContext = await browser.newContext()
+  const viewerContext = await browser.newContext()
+  const ownerPage = await ownerContext.newPage()
+  const viewerPage = await viewerContext.newPage()
+
+  try {
+    await Promise.all([
+      login(ownerPage, 'owner@phase0.test'),
+      login(viewerPage, 'viewer@phase0.test')
+    ])
+    await ownerPage.goto(`/boards/${boardId}`)
+    await ownerPage.getByTestId(`card-${cardId}`).click()
+    await ownerPage.getByLabel('Add new member').click()
+
+    const assignResponse = ownerPage.waitForResponse(
+      (response) => response.url().endsWith(`/cards/${cardId}`) &&
+        response.request().method() === 'PUT' && response.status() === 200
+    )
+    await ownerPage.getByAltText('viewer').click()
+    await assignResponse
+
+    await expect(
+      viewerPage.locator('#basic-button-open-notification .MuiBadge-badge')
+    ).toHaveText('1')
+    await viewerPage.locator('#basic-button-open-notification').click()
+    await expect(
+      viewerPage.getByText(/You were assigned to card/)
+    ).toBeVisible()
+  } finally {
+    await ownerContext.close()
+    await viewerContext.close()
+  }
 })

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -156,6 +156,68 @@ export const updateCardDetailsAPI = async (cardId, updateData) => {
   return response.data
 }
 
+export const setCardArchivedAPI = async (cardId, archived) => {
+  const response = await authorizedAxiosInstance.put(
+    `${API_ROOT}/v1/cards/${cardId}/archive`,
+    { archived }
+  )
+  return response.data
+}
+
+export const copyCardAPI = async (cardId, targetColumnId) => {
+  const response = await authorizedAxiosInstance.post(
+    `${API_ROOT}/v1/cards/${cardId}/copy`,
+    { targetColumnId }
+  )
+  return response.data
+}
+
+export const moveCardAPI = async (cardId, targetColumnId) => {
+  const response = await authorizedAxiosInstance.put(
+    `${API_ROOT}/v1/cards/${cardId}/move`,
+    { targetColumnId }
+  )
+  return response.data
+}
+
+export const uploadCardAttachmentAPI = async (cardId, file) => {
+  const data = new FormData()
+  data.append('attachment', file)
+  const response = await authorizedAxiosInstance.post(
+    `${API_ROOT}/v1/cards/${cardId}/attachments`,
+    data
+  )
+  return response.data
+}
+
+export const deleteCardAttachmentAPI = async (cardId, attachmentId) => {
+  const response = await authorizedAxiosInstance.delete(
+    `${API_ROOT}/v1/cards/${cardId}/attachments/${attachmentId}`
+  )
+  return response.data
+}
+
+export const fetchArchivedCardsAPI = async (boardId) => {
+  const response = await authorizedAxiosInstance.get(
+    `${API_ROOT}/v1/cards/archived/board/${boardId}`
+  )
+  return response.data
+}
+
+export const fetchCardNotificationsAPI = async () => {
+  const response = await authorizedAxiosInstance.get(
+    `${API_ROOT}/v1/notifications`
+  )
+  return response.data
+}
+
+export const markCardNotificationReadAPI = async (notificationId) => {
+  const response = await authorizedAxiosInstance.put(
+    `${API_ROOT}/v1/notifications/${notificationId}/read`
+  )
+  return response.data
+}
+
 export const inviteUserToBoardAPI = async (data) => {
   const response = await authorizedAxiosInstance.post(
     `${API_ROOT}/v1/invitations/board`,

--- a/src/components/AppBar/Notifications/Notifications.jsx
+++ b/src/components/AppBar/Notifications/Notifications.jsx
@@ -73,6 +73,9 @@ function Notifications() {
   // fetch danh sách các lời mới invitations
   useEffect(() => {
     dispatch(fetchInvitationsAPI())
+    fetchCardNotificationsAPI()
+      .then(setCardNotifications)
+      .catch(() => setCardNotifications([]))
 
     // Tạo func xử lý khi nhận được sự kiện real-time
     const onReceiveNewInvitation = (invitation) => {

--- a/src/components/AppBar/Notifications/Notifications.jsx
+++ b/src/components/AppBar/Notifications/Notifications.jsx
@@ -24,19 +24,36 @@ import {
 import { socketIoInstance } from '~/socketClient'
 import { selectCurrentUser } from '~/redux/user/userSlice'
 import { useNavigate } from 'react-router-dom'
+import {
+  fetchCardNotificationsAPI,
+  markCardNotificationReadAPI
+} from '~/apis'
 
 function Notifications() {
   const dispatch = useDispatch()
   const currentUser = useSelector(selectCurrentUser)
   const notifications = useSelector(selectCurrentNotification)
   const [newNotifincation, setNewNotification] = useState(false)
+  const [cardNotifications, setCardNotifications] = useState([])
   const navigate = useNavigate()
 
   const [anchorEl, setAnchorEl] = useState(null)
   const open = Boolean(anchorEl)
-  const handleClickNotificationIcon = (event) => {
+  const handleClickNotificationIcon = async (event) => {
     setAnchorEl(event.currentTarget)
     setNewNotification(false)
+    setCardNotifications(await fetchCardNotificationsAPI())
+  }
+
+  const openCardNotification = async (notification) => {
+    if (!notification.readAt) {
+      await markCardNotificationReadAPI(notification._id)
+      setCardNotifications((current) => current.map((item) =>
+        item._id === notification._id ? { ...item, readAt: Date.now() } : item
+      ))
+    }
+    navigate(`/boards/${notification.boardId}?cardId=${notification.cardId}`)
+    handleClose()
   }
   const handleClose = () => {
     setAnchorEl(null)
@@ -82,7 +99,10 @@ function Notifications() {
       <Tooltip title='Notifications'>
         <Badge
           color='warning'
-          variant={newNotifincation ? 'dot' : 'none'}
+          badgeContent={cardNotifications.filter((item) => !item.readAt).length || undefined}
+          variant={newNotifincation && !cardNotifications.some((item) => !item.readAt)
+            ? 'dot'
+            : 'standard'}
           sx={{ cursor: 'pointer' }}
           id='basic-button-open-notification'
           aria-controls={open ? 'basic-notification-drop-down' : undefined}
@@ -106,11 +126,35 @@ function Notifications() {
         onClose={handleClose}
         MenuListProps={{ 'aria-labelledby': 'basic-button-open-notification' }}
       >
-        {(!notifications || notifications.length === 0) && (
+        {(!notifications || notifications.length === 0) &&
+          cardNotifications.length === 0 && (
           <MenuItem sx={{ minWidth: 200 }}>
             You do not have any new notifications.
           </MenuItem>
         )}
+        {cardNotifications.map((notification) => (
+          <Box key={notification._id}>
+            <MenuItem
+              onClick={() => openCardNotification(notification)}
+              sx={{
+                minWidth: 280,
+                maxWidth: 420,
+                whiteSpace: 'normal',
+                bgcolor: notification.readAt ? 'transparent' : 'action.hover'
+              }}
+            >
+              <Box>
+                <Typography sx={{ fontWeight: notification.readAt ? 400 : 700 }}>
+                  {notification.message}
+                </Typography>
+                <Typography variant='caption' color='text.secondary'>
+                  {moment(notification.createdAt).format('llll')}
+                </Typography>
+              </Box>
+            </MenuItem>
+            <Divider />
+          </Box>
+        ))}
         {notifications?.map((notification, index) => (
           <Box key={index}>
             <MenuItem

--- a/src/components/AppBar/Notifications/Notifications.jsx
+++ b/src/components/AppBar/Notifications/Notifications.jsx
@@ -28,6 +28,11 @@ import {
   fetchCardNotificationsAPI,
   markCardNotificationReadAPI
 } from '~/apis'
+import {
+  CARD_NOTIFICATIONS_UPDATED_EVENT,
+  createNotificationRefreshHandler,
+  startNotificationPolling
+} from '~/realtime/cardNotificationsRealtime'
 
 function Notifications() {
   const dispatch = useDispatch()
@@ -73,9 +78,19 @@ function Notifications() {
   // fetch danh sách các lời mới invitations
   useEffect(() => {
     dispatch(fetchInvitationsAPI())
-    fetchCardNotificationsAPI()
+    const refreshCardNotifications = () => fetchCardNotificationsAPI()
       .then(setCardNotifications)
       .catch(() => setCardNotifications([]))
+    refreshCardNotifications()
+    const {
+      handleNotificationsUpdated,
+      dispose
+    } = createNotificationRefreshHandler({
+      refreshNotifications: refreshCardNotifications
+    })
+    const stopNotificationPolling = startNotificationPolling({
+      refreshNotifications: refreshCardNotifications
+    })
 
     // Tạo func xử lý khi nhận được sự kiện real-time
     const onReceiveNewInvitation = (invitation) => {
@@ -90,10 +105,20 @@ function Notifications() {
 
     // Lắng nghe một sự kiện real time có tên là BE_USER_INVITED_TO_BOARD
     socketIoInstance.on('BE_USER_INVITED_TO_BOARD', onReceiveNewInvitation)
+    socketIoInstance.on(
+      CARD_NOTIFICATIONS_UPDATED_EVENT,
+      handleNotificationsUpdated
+    )
 
     // Clean up sự kiện để ngăn chặn việc bị đăng ký lặp lại event
     return () => {
       socketIoInstance.off('BE_USER_INVITED_TO_BOARD', onReceiveNewInvitation)
+      socketIoInstance.off(
+        CARD_NOTIFICATIONS_UPDATED_EVENT,
+        handleNotificationsUpdated
+      )
+      dispose()
+      stopNotificationPolling()
     }
   }, [dispatch, currentUser._id])
 

--- a/src/components/Modal/ActiveCard/ActiveCard.jsx
+++ b/src/components/Modal/ActiveCard/ActiveCard.jsx
@@ -14,7 +14,6 @@ import AddToDriveOutlinedIcon from '@mui/icons-material/AddToDriveOutlined'
 import AddOutlinedIcon from '@mui/icons-material/AddOutlined'
 import ArrowForwardOutlinedIcon from '@mui/icons-material/ArrowForwardOutlined'
 import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined'
-import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined'
 import ArchiveOutlinedIcon from '@mui/icons-material/ArchiveOutlined'
 import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined'
 import SubjectRoundedIcon from '@mui/icons-material/SubjectRounded'
@@ -427,7 +426,7 @@ function ActiveCard() {
               Actions
             </Typography>
             <Stack direction='column' spacing={1}>
-              <TextField
+              {canEdit && <TextField
                 select
                 size='small'
                 label='Target column'
@@ -438,26 +437,22 @@ function ActiveCard() {
                 {(activeBoard?.columns || []).map((column) => (
                   <MenuItem key={column._id} value={column._id}>{column.title}</MenuItem>
                 ))}
-              </TextField>
-              <SidebarItem onClick={canEdit ? handleMoveCard : undefined}>
+              </TextField>}
+              {canEdit && <SidebarItem onClick={handleMoveCard}>
                 <ArrowForwardOutlinedIcon fontSize='small' />
                 Move
-              </SidebarItem>
-              <SidebarItem onClick={canEdit ? handleCopyCard : undefined}>
+              </SidebarItem>}
+              {canEdit && <SidebarItem onClick={handleCopyCard}>
                 <ContentCopyOutlinedIcon fontSize='small' />
                 Copy
-              </SidebarItem>
-              <SidebarItem>
-                <AutoAwesomeOutlinedIcon fontSize='small' />
-                Make Template
-              </SidebarItem>
-              <SidebarItem
+              </SidebarItem>}
+              {canEdit && <SidebarItem
                 data-testid='archive-active-card'
-                onClick={canEdit ? handleArchiveCard : undefined}
+                onClick={handleArchiveCard}
               >
                 <ArchiveOutlinedIcon fontSize='small' />
                 Archive
-              </SidebarItem>
+              </SidebarItem>}
               <SidebarItem onClick={handleShareCard}>
                 <ShareOutlinedIcon fontSize='small' />
                 Share

--- a/src/components/Modal/ActiveCard/ActiveCard.jsx
+++ b/src/components/Modal/ActiveCard/ActiveCard.jsx
@@ -7,10 +7,6 @@ import Grid from '@mui/material/Unstable_Grid2'
 import Stack from '@mui/material/Stack'
 import Divider from '@mui/material/Divider'
 import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined'
-import LocalOfferOutlinedIcon from '@mui/icons-material/LocalOfferOutlined'
-import TaskAltOutlinedIcon from '@mui/icons-material/TaskAltOutlined'
-import WatchLaterOutlinedIcon from '@mui/icons-material/WatchLaterOutlined'
-import AttachFileOutlinedIcon from '@mui/icons-material/AttachFileOutlined'
 import ImageOutlinedIcon from '@mui/icons-material/ImageOutlined'
 import AutoFixHighOutlinedIcon from '@mui/icons-material/AutoFixHighOutlined'
 import AspectRatioOutlinedIcon from '@mui/icons-material/AspectRatioOutlined'
@@ -31,6 +27,8 @@ import { toast } from 'react-toastify'
 import CardUserGroup from './CardUserGroup'
 import CardDescriptionMdEditor from './CardDescriptionMdEditor'
 import CardActivitySection from './CardActivitySection'
+import CardDetailsPanel from './CardDetailsPanel'
+import CardAttachments from './CardAttachments'
 
 import { styled } from '@mui/material/styles'
 import { useDispatch, useSelector } from 'react-redux'
@@ -40,7 +38,14 @@ import {
   selectIsShowModalActiveCard,
   updateCurrentActiveCard
 } from '~/redux/activeCard/activeCardSlice'
-import { updateCardDetailsAPI } from '~/apis'
+import {
+  copyCardAPI,
+  deleteCardAttachmentAPI,
+  moveCardAPI,
+  setCardArchivedAPI,
+  updateCardDetailsAPI,
+  uploadCardAttachmentAPI
+} from '~/apis'
 import {
   selectCurrentActiveBoard,
   updateCardInBoard
@@ -48,6 +53,10 @@ import {
 import { selectCurrentUser } from '~/redux/user/userSlice'
 import { CARD_MEMBER_ACTIONS } from '~/utils/constants'
 import { canEditBoardContent } from '~/utils/boardPermissions'
+import { useState } from 'react'
+import TextField from '@mui/material/TextField'
+import MenuItem from '@mui/material/MenuItem'
+import { useConfirm } from 'material-ui-confirm'
 const SidebarItem = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
@@ -79,6 +88,8 @@ function ActiveCard() {
   const activeBoard = useSelector(selectCurrentActiveBoard)
   const isShowModalActiveCard = useSelector(selectIsShowModalActiveCard)
   const canEdit = canEditBoardContent(activeBoard?.currentUserRole)
+  const [actionTargetColumnId, setActionTargetColumnId] = useState('')
+  const confirmArchive = useConfirm()
   // const [isOpen, setIsOpen] = useState(true)
   // const handleOpenModal = () => setIsOpen(true)
 
@@ -131,6 +142,65 @@ function ActiveCard() {
   // Dùng async/await ở đây để component con CardActivitySection chờ và nếu thành công thì mới clear thẻ input comment
   const onAddCardComment = async (commentToAdd) => {
     await callAPIUpdateCard({ commentToAdd })
+  }
+
+  const onUpdateCardComment = async (commentId, content) =>
+    await callAPIUpdateCard({ commentToUpdate: { commentId, content } })
+
+  const onDeleteCardComment = async (commentId) =>
+    await callAPIUpdateCard({ commentToDelete: { commentId } })
+
+  const onReactCardComment = async (commentId, emoji) =>
+    await callAPIUpdateCard({ commentReaction: { commentId, emoji } })
+
+  const onUploadAttachment = async (file) => {
+    const updatedCard = await uploadCardAttachmentAPI(activeCard._id, file)
+    dispatch(updateCurrentActiveCard(updatedCard))
+    dispatch(updateCardInBoard(updatedCard))
+  }
+
+  const onDeleteAttachment = async (attachmentId) => {
+    const updatedCard = await deleteCardAttachmentAPI(activeCard._id, attachmentId)
+    dispatch(updateCurrentActiveCard(updatedCard))
+    dispatch(updateCardInBoard(updatedCard))
+  }
+
+  const selectedColumnId = actionTargetColumnId || activeCard?.columnId || ''
+
+  const handleMoveCard = async () => {
+    if (selectedColumnId === activeCard.columnId) return
+    await toast.promise(moveCardAPI(activeCard._id, selectedColumnId), {
+      pending: 'Moving card...',
+      success: 'Card moved'
+    })
+    handleCloseModal()
+  }
+
+  const handleCopyCard = async () => {
+    await toast.promise(copyCardAPI(activeCard._id, selectedColumnId), {
+      pending: 'Copying card...',
+      success: 'Card copied'
+    })
+  }
+
+  const handleArchiveCard = async () => {
+    try {
+      await confirmArchive({
+        title: 'Archive this card?',
+        description: 'The card can be restored from the board archive.'
+      })
+      await setCardArchivedAPI(activeCard._id, true)
+      handleCloseModal()
+      toast.success('Card archived')
+    } catch {
+      // Cancellation leaves the card unchanged.
+    }
+  }
+
+  const handleShareCard = async () => {
+    const url = `${window.location.origin}/boards/${activeBoard._id}?cardId=${activeCard._id}`
+    await navigator.clipboard.writeText(url)
+    toast.success('Card link copied')
   }
 
   const onUpdateCardMembers = (incommingMemberInfo) => {
@@ -239,6 +309,14 @@ function ActiveCard() {
               />
             </Box>
 
+            <CardDetailsPanel
+              key={activeCard?._id}
+              card={activeCard}
+              currentUserId={currentUser?._id}
+              canEdit={canEdit}
+              onUpdate={callAPIUpdateCard}
+            />
+
             <Box sx={{ mb: 3 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                 <SubjectRoundedIcon />
@@ -258,6 +336,13 @@ function ActiveCard() {
               />
             </Box>
 
+            <CardAttachments
+              attachments={activeCard?.attachments}
+              canEdit={canEdit}
+              onUpload={onUploadAttachment}
+              onDelete={onDeleteAttachment}
+            />
+
             <Box sx={{ mb: 3 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                 <DvrOutlinedIcon />
@@ -273,6 +358,9 @@ function ActiveCard() {
               <CardActivitySection
                 cardComments={activeCard?.comments}
                 onAddCardComment={onAddCardComment}
+                onUpdateCardComment={onUpdateCardComment}
+                onDeleteCardComment={onDeleteCardComment}
+                onReactCardComment={onReactCardComment}
                 canComment={canEdit}
               />
             </Box>
@@ -303,22 +391,6 @@ function ActiveCard() {
                 <VisuallyHiddenInput type='file' onChange={onUploadCardCover} />
               </SidebarItem>}
 
-              <SidebarItem>
-                <AttachFileOutlinedIcon fontSize='small' />
-                Attachment
-              </SidebarItem>
-              <SidebarItem>
-                <LocalOfferOutlinedIcon fontSize='small' />
-                Labels
-              </SidebarItem>
-              <SidebarItem>
-                <TaskAltOutlinedIcon fontSize='small' />
-                Checklist
-              </SidebarItem>
-              <SidebarItem>
-                <WatchLaterOutlinedIcon fontSize='small' />
-                Dates
-              </SidebarItem>
               <SidebarItem>
                 <AutoFixHighOutlinedIcon fontSize='small' />
                 Custom Fields
@@ -355,11 +427,23 @@ function ActiveCard() {
               Actions
             </Typography>
             <Stack direction='column' spacing={1}>
-              <SidebarItem>
+              <TextField
+                select
+                size='small'
+                label='Target column'
+                value={selectedColumnId}
+                disabled={!canEdit}
+                onChange={(event) => setActionTargetColumnId(event.target.value)}
+              >
+                {(activeBoard?.columns || []).map((column) => (
+                  <MenuItem key={column._id} value={column._id}>{column.title}</MenuItem>
+                ))}
+              </TextField>
+              <SidebarItem onClick={canEdit ? handleMoveCard : undefined}>
                 <ArrowForwardOutlinedIcon fontSize='small' />
                 Move
               </SidebarItem>
-              <SidebarItem>
+              <SidebarItem onClick={canEdit ? handleCopyCard : undefined}>
                 <ContentCopyOutlinedIcon fontSize='small' />
                 Copy
               </SidebarItem>
@@ -367,11 +451,14 @@ function ActiveCard() {
                 <AutoAwesomeOutlinedIcon fontSize='small' />
                 Make Template
               </SidebarItem>
-              <SidebarItem>
+              <SidebarItem
+                data-testid='archive-active-card'
+                onClick={canEdit ? handleArchiveCard : undefined}
+              >
                 <ArchiveOutlinedIcon fontSize='small' />
                 Archive
               </SidebarItem>
-              <SidebarItem>
+              <SidebarItem onClick={handleShareCard}>
                 <ShareOutlinedIcon fontSize='small' />
                 Share
               </SidebarItem>

--- a/src/components/Modal/ActiveCard/CardActivitySection.jsx
+++ b/src/components/Modal/ActiveCard/CardActivitySection.jsx
@@ -4,6 +4,9 @@ import Typography from '@mui/material/Typography'
 import Avatar from '@mui/material/Avatar'
 import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
+import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
+import { useState } from 'react'
 
 import { useSelector } from 'react-redux'
 import { selectCurrentUser } from '~/redux/user/userSlice'
@@ -11,9 +14,14 @@ import { selectCurrentUser } from '~/redux/user/userSlice'
 function CardActivitySection({
   cardComments = [],
   onAddCardComment,
+  onUpdateCardComment,
+  onDeleteCardComment,
+  onReactCardComment,
   canComment
 }) {
   const currentUser = useSelector(selectCurrentUser)
+  const [editingCommentId, setEditingCommentId] = useState(null)
+  const [editingContent, setEditingContent] = useState('')
 
   const handleAddCardComment = (event) => {
     // Bắt hành động người dùng nhấn phím Enter && không phải hành động Shift + Enter
@@ -67,7 +75,7 @@ function CardActivitySection({
       {cardComments.map((comment, index) => (
         <Box
           sx={{ display: 'flex', gap: 1, width: '100%', mb: 1.5 }}
-          key={index}
+          key={comment._id || index}
         >
           <Tooltip title='trungquandev'>
             <Avatar
@@ -85,7 +93,20 @@ function CardActivitySection({
               {moment(comment.commentedAt).format('llll')}
             </Typography>
 
-            <Box
+            {editingCommentId === comment._id ? <TextField
+              fullWidth
+              multiline
+              size='small'
+              value={editingContent}
+              onChange={(event) => setEditingContent(event.target.value)}
+              onKeyDown={async (event) => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault()
+                  await onUpdateCardComment(comment._id, editingContent.trim())
+                  setEditingCommentId(null)
+                }
+              }}
+            /> : <Box
               sx={{
                 display: 'block',
                 bgcolor: (theme) =>
@@ -99,7 +120,42 @@ function CardActivitySection({
               }}
             >
               {comment.content}
-            </Box>
+              {comment.editedAt && <Typography
+                component='span'
+                sx={{ ml: 1, fontSize: 11, color: 'text.secondary' }}
+              >
+                (edited)
+              </Typography>}
+            </Box>}
+            {comment._id && canComment && <Stack direction='row' spacing={0.5} sx={{ mt: 0.5 }}>
+              {['👍', '❤️', '🎉'].map((emoji) => {
+                const reaction = comment.reactions?.find((item) => item.emoji === emoji)
+                return <Button
+                  key={emoji}
+                  size='small'
+                  variant={reaction?.userIds?.includes(currentUser?._id)
+                    ? 'contained'
+                    : 'text'}
+                  onClick={() => onReactCardComment(comment._id, emoji)}
+                >
+                  {emoji}{reaction?.userIds?.length ? ` ${reaction.userIds.length}` : ''}
+                </Button>
+              })}
+              {comment.userId === currentUser?._id && <>
+                <Button
+                  size='small'
+                  onClick={() => {
+                    setEditingCommentId(comment._id)
+                    setEditingContent(comment.content)
+                  }}
+                >Edit</Button>
+                <Button
+                  size='small'
+                  color='error'
+                  onClick={() => onDeleteCardComment(comment._id)}
+                >Delete</Button>
+              </>}
+            </Stack>}
           </Box>
         </Box>
       ))}

--- a/src/components/Modal/ActiveCard/CardAttachments.jsx
+++ b/src/components/Modal/ActiveCard/CardAttachments.jsx
@@ -1,0 +1,76 @@
+import {
+  Box,
+  Button,
+  Link,
+  List,
+  ListItem,
+  ListItemText,
+  Typography
+} from '@mui/material'
+import AttachFileIcon from '@mui/icons-material/AttachFile'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import VisuallyHiddenInput from '~/components/Form/VisuallyHiddenInput'
+import { attachmentFileValidator } from '~/utils/validators'
+import { toast } from 'react-toastify'
+
+function CardAttachments({ attachments = [], canEdit, onUpload, onDelete }) {
+  const handleUpload = async (event) => {
+    const file = event.target.files?.[0]
+    const error = attachmentFileValidator(file)
+    if (error) {
+      toast.error(error)
+      return
+    }
+    try {
+      await toast.promise(onUpload(file), { pending: 'Uploading attachment...' })
+    } finally {
+      event.target.value = ''
+    }
+  }
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <AttachFileIcon />
+        <Typography sx={{ fontWeight: 600, fontSize: 20, flex: 1 }}>
+          Attachments
+        </Typography>
+        {canEdit && <Button component='label' variant='outlined' size='small'>
+          Add
+          <VisuallyHiddenInput type='file' onChange={handleUpload} />
+        </Button>}
+      </Box>
+      {attachments.length === 0 ? (
+        <Typography color='text.secondary' sx={{ mt: 1 }}>No attachments</Typography>
+      ) : (
+        <List dense>
+          {attachments.map((attachment) => (
+            <ListItem
+              key={attachment._id}
+              secondaryAction={canEdit && (
+                <Button
+                  color='error'
+                  aria-label={`Delete ${attachment.name}`}
+                  onClick={() => onDelete(attachment._id)}
+                >
+                  <DeleteOutlineIcon />
+                </Button>
+              )}
+            >
+              <ListItemText
+                primary={
+                  <Link href={attachment.url} target='_blank' rel='noreferrer'>
+                    {attachment.name}
+                  </Link>
+                }
+                secondary={`${Math.ceil(attachment.size / 1024)} KB`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  )
+}
+
+export default CardAttachments

--- a/src/components/Modal/ActiveCard/CardDetailsPanel.jsx
+++ b/src/components/Modal/ActiveCard/CardDetailsPanel.jsx
@@ -1,0 +1,231 @@
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  LinearProgress,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import { CARD_PRIORITIES } from '~/utils/constants'
+
+const toDateTimeInput = (timestamp) => {
+  if (!timestamp) return ''
+  const date = new Date(timestamp)
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000)
+    .toISOString()
+    .slice(0, 16)
+}
+
+function CardDetailsPanel({ card, currentUserId, canEdit, onUpdate }) {
+  const [startDate, setStartDate] = useState(toDateTimeInput(card?.startDate))
+  const [dueDate, setDueDate] = useState(toDateTimeInput(card?.dueDate))
+  const [labelName, setLabelName] = useState('')
+  const [labelColor, setLabelColor] = useState('#0C66E4')
+  const [checklistTitle, setChecklistTitle] = useState('')
+  const checklist = card?.checklist || []
+  const completedItems = checklist.filter((item) => item.isCompleted).length
+  const progress = checklist.length
+    ? Math.round((completedItems / checklist.length) * 100)
+    : 0
+
+  const saveDates = () => onUpdate({
+    startDate: startDate ? new Date(startDate).getTime() : null,
+    dueDate: dueDate ? new Date(dueDate).getTime() : null
+  })
+
+  const addLabel = async () => {
+    const name = labelName.trim()
+    if (!name) return
+    await onUpdate({
+      labels: [...(card?.labels || []), { name, color: labelColor }]
+    })
+    setLabelName('')
+  }
+
+  const addChecklistItem = async () => {
+    const title = checklistTitle.trim()
+    if (!title) return
+    await onUpdate({
+      checklist: [...checklist, { title, isCompleted: false }]
+    })
+    setChecklistTitle('')
+  }
+
+  const updateChecklistItem = (itemId, changes) => onUpdate({
+    checklist: checklist.map((item) =>
+      item._id === itemId ? { ...item, ...changes } : item
+    )
+  })
+
+  const isWatching = card?.watcherIds?.includes(currentUserId)
+
+  return (
+    <Stack spacing={3} sx={{ mb: 3 }}>
+      <Box>
+        <Typography sx={{ fontWeight: 600, mb: 1 }}>Priority & status</Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <FormControl size='small' sx={{ minWidth: 160 }} disabled={!canEdit}>
+            <InputLabel>Priority</InputLabel>
+            <Select
+              label='Priority'
+              value={card?.priority || CARD_PRIORITIES.MEDIUM}
+              onChange={(event) => onUpdate({ priority: event.target.value })}
+            >
+              {Object.values(CARD_PRIORITIES).map((priority) => (
+                <MenuItem key={priority} value={priority}>{priority}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={Boolean(card?.completedAt)}
+                disabled={!canEdit}
+                onChange={(event) => onUpdate({
+                  completedAt: event.target.checked ? Date.now() : null
+                })}
+              />
+            }
+            label='Completed'
+          />
+          <Button
+            variant={isWatching ? 'contained' : 'outlined'}
+            disabled={!canEdit}
+            onClick={() => onUpdate({
+              watcherIds: isWatching
+                ? card.watcherIds.filter((id) => id !== currentUserId)
+                : [...(card?.watcherIds || []), currentUserId]
+            })}
+          >
+            {isWatching ? 'Watching' : 'Watch'}
+          </Button>
+        </Stack>
+      </Box>
+
+      <Box>
+        <Typography sx={{ fontWeight: 600, mb: 1 }}>Dates</Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+          <TextField
+            label='Start date'
+            type='datetime-local'
+            size='small'
+            value={startDate}
+            disabled={!canEdit}
+            onChange={(event) => setStartDate(event.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            label='Due date'
+            type='datetime-local'
+            size='small'
+            value={dueDate}
+            disabled={!canEdit}
+            onChange={(event) => setDueDate(event.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          {canEdit && <Button variant='outlined' onClick={saveDates}>Save dates</Button>}
+        </Stack>
+      </Box>
+
+      <Box>
+        <Typography sx={{ fontWeight: 600, mb: 1 }}>Labels</Typography>
+        <Stack direction='row' spacing={1} useFlexGap flexWrap='wrap' sx={{ mb: 1 }}>
+          {(card?.labels || []).map((label) => (
+            <Chip
+              key={label._id}
+              label={label.name}
+              sx={{ bgcolor: label.color, color: '#fff' }}
+              onDelete={canEdit
+                ? () => onUpdate({
+                  labels: card.labels.filter((item) => item._id !== label._id)
+                })
+                : undefined}
+            />
+          ))}
+        </Stack>
+        {canEdit && <Stack direction='row' spacing={1}>
+          <TextField
+            size='small'
+            label='Label name'
+            value={labelName}
+            onChange={(event) => setLabelName(event.target.value)}
+          />
+          <TextField
+            size='small'
+            type='color'
+            value={labelColor}
+            onChange={(event) => setLabelColor(event.target.value)}
+            sx={{ width: 64 }}
+          />
+          <Button
+            aria-label='Add label'
+            startIcon={<AddIcon />}
+            onClick={addLabel}
+          >Add</Button>
+        </Stack>}
+      </Box>
+
+      <Box>
+        <Typography sx={{ fontWeight: 600 }}>Checklist ({progress}%)</Typography>
+        <LinearProgress variant='determinate' value={progress} sx={{ my: 1 }} />
+        <Stack spacing={0.5}>
+          {checklist.map((item) => (
+            <Stack key={item._id} direction='row' alignItems='center'>
+              <Checkbox
+                checked={item.isCompleted}
+                disabled={!canEdit}
+                onChange={(event) => updateChecklistItem(item._id, {
+                  isCompleted: event.target.checked
+                })}
+              />
+              <Typography
+                sx={{
+                  flex: 1,
+                  textDecoration: item.isCompleted ? 'line-through' : 'none'
+                }}
+              >
+                {item.title}
+              </Typography>
+              {canEdit && <Button
+                color='error'
+                aria-label={`Delete ${item.title}`}
+                onClick={() => onUpdate({
+                  checklist: checklist.filter((entry) => entry._id !== item._id)
+                })}
+              >
+                <DeleteOutlineIcon />
+              </Button>}
+            </Stack>
+          ))}
+        </Stack>
+        {canEdit && <Stack direction='row' spacing={1} sx={{ mt: 1 }}>
+          <TextField
+            fullWidth
+            size='small'
+            label='Checklist item'
+            value={checklistTitle}
+            onChange={(event) => setChecklistTitle(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') addChecklistItem()
+            }}
+          />
+          <Button aria-label='Add checklist item' onClick={addChecklistItem}>
+            Add
+          </Button>
+        </Stack>}
+      </Box>
+    </Stack>
+  )
+}
+
+export default CardDetailsPanel

--- a/src/components/Modal/ActiveCard/CardDetailsPanel.jsx
+++ b/src/components/Modal/ActiveCard/CardDetailsPanel.jsx
@@ -17,14 +17,12 @@ import {
 import AddIcon from '@mui/icons-material/Add'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { CARD_PRIORITIES } from '~/utils/constants'
-
-const toDateTimeInput = (timestamp) => {
-  if (!timestamp) return ''
-  const date = new Date(timestamp)
-  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000)
-    .toISOString()
-    .slice(0, 16)
-}
+import {
+  dateTimeInputToTimestamp,
+  getChecklistProgress,
+  toDateTimeInput,
+  toggleWatcher
+} from '~/utils/cardPhase1'
 
 function CardDetailsPanel({ card, currentUserId, canEdit, onUpdate }) {
   const [startDate, setStartDate] = useState(toDateTimeInput(card?.startDate))
@@ -33,14 +31,11 @@ function CardDetailsPanel({ card, currentUserId, canEdit, onUpdate }) {
   const [labelColor, setLabelColor] = useState('#0C66E4')
   const [checklistTitle, setChecklistTitle] = useState('')
   const checklist = card?.checklist || []
-  const completedItems = checklist.filter((item) => item.isCompleted).length
-  const progress = checklist.length
-    ? Math.round((completedItems / checklist.length) * 100)
-    : 0
+  const { percentage: progress } = getChecklistProgress(checklist)
 
   const saveDates = () => onUpdate({
-    startDate: startDate ? new Date(startDate).getTime() : null,
-    dueDate: dueDate ? new Date(dueDate).getTime() : null
+    startDate: dateTimeInputToTimestamp(startDate),
+    dueDate: dateTimeInputToTimestamp(dueDate)
   })
 
   const addLabel = async () => {
@@ -89,6 +84,7 @@ function CardDetailsPanel({ card, currentUserId, canEdit, onUpdate }) {
           <FormControlLabel
             control={
               <Checkbox
+                inputProps={{ 'aria-label': 'Card completed' }}
                 checked={Boolean(card?.completedAt)}
                 disabled={!canEdit}
                 onChange={(event) => onUpdate({
@@ -102,9 +98,7 @@ function CardDetailsPanel({ card, currentUserId, canEdit, onUpdate }) {
             variant={isWatching ? 'contained' : 'outlined'}
             disabled={!canEdit}
             onClick={() => onUpdate({
-              watcherIds: isWatching
-                ? card.watcherIds.filter((id) => id !== currentUserId)
-                : [...(card?.watcherIds || []), currentUserId]
+              watcherIds: toggleWatcher(card?.watcherIds, currentUserId)
             })}
           >
             {isWatching ? 'Watching' : 'Watch'}
@@ -182,6 +176,7 @@ function CardDetailsPanel({ card, currentUserId, canEdit, onUpdate }) {
           {checklist.map((item) => (
             <Stack key={item._id} direction='row' alignItems='center'>
               <Checkbox
+                inputProps={{ 'aria-label': `Complete ${item.title}` }}
                 checked={item.isCompleted}
                 disabled={!canEdit}
                 onChange={(event) => updateChecklistItem(item._id, {

--- a/src/pages/Boards/BoardBar/ArchivedCardsDrawer.jsx
+++ b/src/pages/Boards/BoardBar/ArchivedCardsDrawer.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Typography
+} from '@mui/material'
+import ArchiveOutlinedIcon from '@mui/icons-material/ArchiveOutlined'
+import CloseIcon from '@mui/icons-material/Close'
+import { fetchArchivedCardsAPI, setCardArchivedAPI } from '~/apis'
+import { toast } from 'react-toastify'
+
+function ArchivedCardsDrawer({ boardId, canEdit }) {
+  const [open, setOpen] = useState(false)
+  const [cards, setCards] = useState([])
+
+  const loadCards = async () => {
+    const archivedCards = await fetchArchivedCardsAPI(boardId)
+    setCards(archivedCards)
+  }
+
+  const handleOpen = async () => {
+    setOpen(true)
+    await loadCards()
+  }
+
+  const restoreCard = async (cardId) => {
+    await setCardArchivedAPI(cardId, false)
+    setCards((current) => current.filter((card) => card._id !== cardId))
+    toast.success('Card restored')
+  }
+
+  return <>
+    <Button color='inherit' startIcon={<ArchiveOutlinedIcon />} onClick={handleOpen}>
+      Archive
+    </Button>
+    <Drawer anchor='right' open={open} onClose={() => setOpen(false)}>
+      <Box sx={{ width: 360, p: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Typography variant='h6' sx={{ flex: 1 }}>Archived cards</Typography>
+          <IconButton onClick={() => setOpen(false)}><CloseIcon /></IconButton>
+        </Box>
+        {cards.length === 0 && <Typography color='text.secondary'>No archived cards</Typography>}
+        <List>
+          {cards.map((card) => (
+            <ListItem
+              key={card._id}
+              secondaryAction={canEdit && (
+                <Button onClick={() => restoreCard(card._id)}>Restore</Button>
+              )}
+            >
+              <ListItemText
+                primary={card.title}
+                secondary={card.archivedAt
+                  ? new Date(card.archivedAt).toLocaleString()
+                  : undefined}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </Box>
+    </Drawer>
+  </>
+}
+
+export default ArchivedCardsDrawer

--- a/src/pages/Boards/BoardBar/BoardBar.jsx
+++ b/src/pages/Boards/BoardBar/BoardBar.jsx
@@ -10,7 +10,11 @@ import { useSelector } from 'react-redux'
 import { selectCurrentActiveBoard } from '~/redux/activeBoard/activeBoardSlice'
 import InviteBoardUser from './InviteBoardUser'
 import BoardActivityDrawer from './BoardActivityDrawer'
-import { canManageBoard } from '~/utils/boardPermissions'
+import {
+  canEditBoardContent,
+  canManageBoard
+} from '~/utils/boardPermissions'
+import ArchivedCardsDrawer from './ArchivedCardsDrawer'
 
 const MENU_STYLES = {
   color: 'white',
@@ -29,6 +33,7 @@ const MENU_STYLES = {
 function BoardBar({ board }) {
   const activeBoard = useSelector(selectCurrentActiveBoard)
   const canInvite = canManageBoard(board.currentUserRole)
+  const canEdit = canEditBoardContent(board.currentUserRole)
 
   return (
     <Box
@@ -95,6 +100,7 @@ function BoardBar({ board }) {
         }}
       >
         <BoardActivityDrawer boardId={board._id} />
+        <ArchivedCardsDrawer boardId={board._id} canEdit={canEdit} />
 
         {/* Xử lý mời user vào làm thành viên của board*/}
         {canInvite && <InviteBoardUser boardId={board._id} />}

--- a/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
@@ -65,6 +65,12 @@ function Card({ card, canEdit }) {
     ? (completedChecklistItems / card.checklist.length) * 100
     : 0
   const isOverdue = card?.dueDate && !card?.completedAt && card.dueDate < Date.now()
+  const priorityColors = {
+    LOW: 'success',
+    MEDIUM: 'info',
+    HIGH: 'warning',
+    URGENT: 'error'
+  }
 
   const setActiveCard = () => {
     dispatch(updateCurrentActiveCard(card))
@@ -103,6 +109,12 @@ function Card({ card, canEdit }) {
             />
           ))}
         </Box>}
+        {card?.priority && <Chip
+          size='small'
+          color={priorityColors[card.priority] || 'default'}
+          label={card.priority}
+          sx={{ mb: 1 }}
+        />}
         <Typography>{card?.title}</Typography>
         {!!card?.checklist?.length && <LinearProgress
           variant='determinate'

--- a/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
@@ -1,8 +1,11 @@
 import {
   Button,
+  Box,
   CardActions,
   CardContent,
   CardMedia,
+  Chip,
+  LinearProgress,
   Tooltip,
   Typography
 } from '@mui/material'
@@ -10,6 +13,8 @@ import { Card as MuiCard } from '@mui/material'
 import GroupIcon from '@mui/icons-material/Group'
 import CommentIcon from '@mui/icons-material/Comment'
 import AttachmentIcon from '@mui/icons-material/Attachment'
+import AccessTimeIcon from '@mui/icons-material/AccessTime'
+import ChecklistIcon from '@mui/icons-material/Checklist'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useDispatch } from 'react-redux'
@@ -47,9 +52,19 @@ function Card({ card, canEdit }) {
     return (
       !!card?.memberIds?.length ||
       !!card?.comments?.length ||
-      !!card?.attachments?.length
+      !!card?.attachments?.length ||
+      !!card?.dueDate ||
+      !!card?.checklist?.length
     )
   }
+
+  const completedChecklistItems = card?.checklist?.filter(
+    (item) => item.isCompleted
+  ).length || 0
+  const checklistProgress = card?.checklist?.length
+    ? (completedChecklistItems / card.checklist.length) * 100
+    : 0
+  const isOverdue = card?.dueDate && !card?.completedAt && card.dueDate < Date.now()
 
   const setActiveCard = () => {
     dispatch(updateCurrentActiveCard(card))
@@ -76,7 +91,25 @@ function Card({ card, canEdit }) {
       {card?.cover && <CardMedia sx={{ height: 140 }} image={card?.cover} />}
 
       <CardContent sx={{ p: 1.5, '&:last-child': { p: 1.5 } }}>
+        {!!card?.labels?.length && <Box
+          sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 1 }}
+        >
+          {card.labels.map((label) => (
+            <Chip
+              key={label._id}
+              size='small'
+              label={label.name}
+              sx={{ bgcolor: label.color, color: '#fff' }}
+            />
+          ))}
+        </Box>}
         <Typography>{card?.title}</Typography>
+        {!!card?.checklist?.length && <LinearProgress
+          variant='determinate'
+          value={checklistProgress}
+          color={checklistProgress === 100 ? 'success' : 'primary'}
+          sx={{ mt: 1 }}
+        />}
       </CardContent>
       {shouldShowCardActions() && (
         <CardActions sx={{ p: '0 4px 8px 4px' }}>
@@ -97,6 +130,20 @@ function Card({ card, canEdit }) {
           {!!card?.attachments?.length && (
             <Button size='small' startIcon={<AttachmentIcon />}>
               {card?.attachments?.length}
+            </Button>
+          )}
+          {!!card?.checklist?.length && (
+            <Button size='small' startIcon={<ChecklistIcon />}>
+              {completedChecklistItems}/{card.checklist.length}
+            </Button>
+          )}
+          {!!card?.dueDate && (
+            <Button
+              size='small'
+              color={isOverdue ? 'error' : card.completedAt ? 'success' : 'inherit'}
+              startIcon={<AccessTimeIcon />}
+            >
+              {new Date(card.dueDate).toLocaleDateString()}
             </Button>
           )}
         </CardActions>

--- a/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/ListCards/Card/Card.jsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   Typography
 } from '@mui/material'
+import { isCardOverdue } from '~/utils/cardPhase1'
 import { Card as MuiCard } from '@mui/material'
 import GroupIcon from '@mui/icons-material/Group'
 import CommentIcon from '@mui/icons-material/Comment'
@@ -64,7 +65,7 @@ function Card({ card, canEdit }) {
   const checklistProgress = card?.checklist?.length
     ? (completedChecklistItems / card.checklist.length) * 100
     : 0
-  const isOverdue = card?.dueDate && !card?.completedAt && card.dueDate < Date.now()
+  const isOverdue = isCardOverdue(card)
   const priorityColors = {
     LOW: 'success',
     MEDIUM: 'info',

--- a/src/pages/Boards/_id.jsx
+++ b/src/pages/Boards/_id.jsx
@@ -15,7 +15,7 @@ import {
   selectCurrentActiveBoard
 } from '~/redux/activeBoard/activeBoardSlice'
 import { useSelector, useDispatch } from 'react-redux'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import PageLoadingSpinner from '~/components/Loading/PageLoadingSpinner'
 import ActiveCard from '~/components/Modal/ActiveCard/ActiveCard'
 import { socketIoInstance } from '~/socketClient'
@@ -24,6 +24,10 @@ import {
   BOARD_UPDATED_EVENT,
   createBoardRefreshHandler
 } from '~/realtime/boardRealtime'
+import {
+  showModalActiveCard,
+  updateCurrentActiveCard
+} from '~/redux/activeCard/activeCardSlice'
 
 function Board() {
   const dispatch = useDispatch()
@@ -31,6 +35,7 @@ function Board() {
   const board = useSelector(selectCurrentActiveBoard)
 
   const { boardId } = useParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const canEdit = canEditBoardContent(board?.currentUserRole)
 
   useEffect(() => {
@@ -55,6 +60,19 @@ function Board() {
       socketIoInstance.emit('FE_LEAVE_BOARD', boardId)
     }
   }, [dispatch, boardId])
+
+  useEffect(() => {
+    const cardId = searchParams.get('cardId')
+    if (!board || !cardId) return
+    const card = board.columns
+      .flatMap((column) => column.cards)
+      .find((item) => item._id === cardId)
+    if (card) {
+      dispatch(updateCurrentActiveCard(card))
+      dispatch(showModalActiveCard())
+    }
+    setSearchParams({}, { replace: true })
+  }, [board, dispatch, searchParams, setSearchParams])
 
   /* Gọi Api và xử lý kéo thả column
   Cập nhật mảng columnOrderIds của board chứa column (thay đổi vị trí) */

--- a/src/realtime/cardNotificationsRealtime.js
+++ b/src/realtime/cardNotificationsRealtime.js
@@ -1,0 +1,36 @@
+export const CARD_NOTIFICATIONS_UPDATED_EVENT =
+  'BE_CARD_NOTIFICATIONS_UPDATED'
+
+export const createNotificationRefreshHandler = ({
+  refreshNotifications,
+  schedule = setTimeout,
+  cancel = clearTimeout,
+  delay = 100
+}) => {
+  let pendingTimer
+
+  const handleNotificationsUpdated = () => {
+    if (pendingTimer) cancel(pendingTimer)
+    pendingTimer = schedule(() => {
+      pendingTimer = undefined
+      refreshNotifications()
+    }, delay)
+  }
+
+  const dispose = () => {
+    if (pendingTimer) cancel(pendingTimer)
+    pendingTimer = undefined
+  }
+
+  return { handleNotificationsUpdated, dispose }
+}
+
+export const startNotificationPolling = ({
+  refreshNotifications,
+  schedule = setInterval,
+  cancel = clearInterval,
+  interval = 60_000
+}) => {
+  const intervalId = schedule(refreshNotifications, interval)
+  return () => cancel(intervalId)
+}

--- a/src/utils/cardPhase1.js
+++ b/src/utils/cardPhase1.js
@@ -1,0 +1,35 @@
+export const toDateTimeInput = (value) => {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000)
+    .toISOString()
+    .slice(0, 16)
+}
+
+export const dateTimeInputToTimestamp = (value) =>
+  value ? new Date(value).getTime() : null
+
+export const getChecklistProgress = (checklist = []) => {
+  if (!checklist.length) return { completed: 0, total: 0, percentage: 0 }
+  const completed = checklist.filter((item) => item.isCompleted).length
+
+  return {
+    completed,
+    total: checklist.length,
+    percentage: Math.round((completed / checklist.length) * 100)
+  }
+}
+
+export const toggleWatcher = (watcherIds = [], userId) =>
+  watcherIds.includes(userId)
+    ? watcherIds.filter((id) => id !== userId)
+    : [...watcherIds, userId]
+
+export const isCardOverdue = (card, now = Date.now()) =>
+  Boolean(
+    card?.dueDate &&
+    !card?.completedAt &&
+    new Date(card.dueDate).getTime() < now
+  )

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -16,3 +16,10 @@ export const CARD_MEMBER_ACTIONS = {
   ADD: 'ADD',
   REMOVE: 'REMOVE'
 }
+
+export const CARD_PRIORITIES = {
+  LOW: 'LOW',
+  MEDIUM: 'MEDIUM',
+  HIGH: 'HIGH',
+  URGENT: 'URGENT'
+}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -12,6 +12,13 @@ export const PASSWORD_CONFIRMATION_MESSAGE =
 // Liên quan đến Validate File
 export const LIMIT_COMMON_FILE_SIZE = 10485760 // byte = 10 MB
 export const ALLOW_COMMON_FILE_TYPES = ['image/jpg', 'image/jpeg', 'image/png']
+export const ALLOW_ATTACHMENT_FILE_TYPES = [
+  ...ALLOW_COMMON_FILE_TYPES,
+  'application/pdf',
+  'text/plain',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+]
 export const singleFileValidator = (file) => {
   if (!file || !file.name || !file.size || !file.type) {
     return 'File cannot be blank.'
@@ -21,6 +28,19 @@ export const singleFileValidator = (file) => {
   }
   if (!ALLOW_COMMON_FILE_TYPES.includes(file.type)) {
     return 'File type is invalid. Only accept jpg, jpeg and png'
+  }
+  return null
+}
+
+export const attachmentFileValidator = (file) => {
+  if (!file || !file.name || !file.size || !file.type) {
+    return 'File cannot be blank.'
+  }
+  if (file.size > LIMIT_COMMON_FILE_SIZE) {
+    return 'Maximum file size exceeded. (10MB)'
+  }
+  if (!ALLOW_ATTACHMENT_FILE_TYPES.includes(file.type)) {
+    return 'Attachment type is invalid.'
   }
   return null
 }

--- a/tests/cardNotificationsRealtime.test.js
+++ b/tests/cardNotificationsRealtime.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CARD_NOTIFICATIONS_UPDATED_EVENT,
+  createNotificationRefreshHandler,
+  startNotificationPolling
+} from '../src/realtime/cardNotificationsRealtime.js'
+
+test('uses the backend card notification event name', () => {
+  assert.equal(
+    CARD_NOTIFICATIONS_UPDATED_EVENT,
+    'BE_CARD_NOTIFICATIONS_UPDATED'
+  )
+})
+
+test('coalesces rapid notification refreshes and supports cleanup', () => {
+  const scheduled = new Map()
+  const cancelled = []
+  let nextTimerId = 0
+  let refreshCount = 0
+  const schedule = (callback) => {
+    nextTimerId += 1
+    scheduled.set(nextTimerId, callback)
+    return nextTimerId
+  }
+  const cancel = (timerId) => {
+    cancelled.push(timerId)
+    scheduled.delete(timerId)
+  }
+  const {
+    handleNotificationsUpdated,
+    dispose
+  } = createNotificationRefreshHandler({
+    refreshNotifications: () => {
+      refreshCount += 1
+    },
+    schedule,
+    cancel
+  })
+
+  handleNotificationsUpdated()
+  handleNotificationsUpdated()
+  assert.deepEqual(cancelled, [1])
+  const scheduledRefresh = scheduled.get(2)
+  scheduled.delete(2)
+  scheduledRefresh()
+  assert.equal(refreshCount, 1)
+
+  handleNotificationsUpdated()
+  dispose()
+  assert.deepEqual(cancelled, [1, 3])
+  assert.equal(scheduled.size, 0)
+})
+
+test('polls due notifications and clears the interval on cleanup', () => {
+  let scheduledCallback
+  let scheduledInterval
+  let cancelledInterval
+  let refreshCount = 0
+  const stop = startNotificationPolling({
+    refreshNotifications: () => {
+      refreshCount += 1
+    },
+    schedule: (callback, interval) => {
+      scheduledCallback = callback
+      scheduledInterval = interval
+      return 42
+    },
+    cancel: (intervalId) => {
+      cancelledInterval = intervalId
+    }
+  })
+
+  assert.equal(scheduledInterval, 60_000)
+  scheduledCallback()
+  assert.equal(refreshCount, 1)
+  stop()
+  assert.equal(cancelledInterval, 42)
+})

--- a/tests/cardPhase1.test.js
+++ b/tests/cardPhase1.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  dateTimeInputToTimestamp,
+  getChecklistProgress,
+  isCardOverdue,
+  toDateTimeInput,
+  toggleWatcher
+} from '../src/utils/cardPhase1.js'
+
+test('converts phase one date inputs in both directions', () => {
+  const timestamp = dateTimeInputToTimestamp('2030-01-02T09:30')
+
+  assert.equal(Number.isFinite(timestamp), true)
+  assert.equal(toDateTimeInput(timestamp), '2030-01-02T09:30')
+  assert.equal(dateTimeInputToTimestamp(''), null)
+  assert.equal(toDateTimeInput('invalid'), '')
+})
+
+test('calculates checklist progress including the empty state', () => {
+  assert.deepEqual(getChecklistProgress(), {
+    completed: 0,
+    total: 0,
+    percentage: 0
+  })
+  assert.deepEqual(
+    getChecklistProgress([
+      { isCompleted: true },
+      { isCompleted: false },
+      { isCompleted: true }
+    ]),
+    { completed: 2, total: 3, percentage: 67 }
+  )
+})
+
+test('toggles only the current watcher without mutating the source', () => {
+  const watchers = ['user-1']
+
+  assert.deepEqual(toggleWatcher(watchers, 'user-2'), ['user-1', 'user-2'])
+  assert.deepEqual(toggleWatcher(watchers, 'user-1'), [])
+  assert.deepEqual(watchers, ['user-1'])
+})
+
+test('detects overdue numeric, Date, and ISO deadlines consistently', () => {
+  const now = 1_800_000_000_000
+  const overdue = now - 1
+
+  assert.equal(isCardOverdue({ dueDate: overdue }, now), true)
+  assert.equal(isCardOverdue({ dueDate: new Date(overdue) }, now), true)
+  assert.equal(isCardOverdue({ dueDate: new Date(overdue).toISOString() }, now), true)
+  assert.equal(
+    isCardOverdue({ dueDate: overdue, completedAt: now - 100 }, now),
+    false
+  )
+  assert.equal(isCardOverdue({ dueDate: now + 1 }, now), false)
+})


### PR DESCRIPTION
## Summary

Deliver the complete Phase 1 card experience in the Web application: users can plan with priority and dates, manage labels/checklists/attachments/watchers, perform card lifecycle actions, collaborate through richer comments, and receive actionable card notifications.

The final audit also fixes inconsistent overdue handling across timestamp/Date/ISO values and keeps notification badges current through authenticated realtime events plus due-reminder polling.

## Related work

- Closes: Phase 1 — Complete cards
- Depends on: [Trello-Api Phase 1 PR #37](https://github.com/dhoangvu1811/Trello-Api/pull/37)

## Change type

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Performance
- [ ] Security
- [x] Test or documentation
- [ ] Build, CI, or dependency update
- [ ] Breaking change

## What changed

- Added priority, completed status, watch/unwatch, start/due dates, colored labels, checklist management, and progress UI to the active-card modal.
- Added attachment upload/list/delete UI with client-side file validation.
- Added move, copy, archive, share-link actions and an archived-card restore drawer.
- Added comment edit/delete/reaction controls while preserving author-only mutation behavior from the API.
- Added card badges for priority, labels, checklist progress, attachments, due dates, and overdue state.
- Added card notification menu entries, read state, internal card deep links, realtime refresh, debouncing, and 60-second due reminder polling with cleanup.
- Aligned all mutation controls with board roles so viewers remain read-only.
- Added unit and Playwright scenarios covering Phase 1 card details, collaboration, lifecycle actions, sharing, and realtime notifications.

## User experience

Before this PR, most Phase 1 controls in the card modal were placeholders and remote card notifications required a page/menu refresh. After this PR, card details and lifecycle actions are fully functional, board cards surface relevant planning state, archived cards can be restored, shared links reopen the intended card, and assignment/mention/move/reminder notifications stay current.

Viewers can inspect card information but cannot mutate card content, upload/delete attachments, change details, drag cards, or perform lifecycle actions.

### Screenshots or recordings

| Before | After |
| --- | --- |
| Phase 1 controls were missing or placeholders | Functional card details, badges, lifecycle actions, archive drawer, comments, attachments, and notifications |

## Technical impact

### API and data contract

- API endpoints affected: `PUT /V1/cards/:id`, archive/copy/move/attachment endpoints, archived-card listing, and notification list/read endpoints.
- Request/response contract changed: Consumes the additive Phase 1 card fields, embedded comment metadata, attachment metadata, and notification documents introduced by the API PR.
- Compatible API PR/deployment required: Yes — [Trello-Api #37](https://github.com/dhoangvu1811/Trello-Api/pull/37).

### State, authentication, and realtime

- Redux/persisted state affected: Active card and active board card entries are updated after Phase 1 mutations; no new persisted credential state.
- Login, cookie, token, or permission behavior affected: No authentication changes; UI mutation controls now consistently follow the current board role.
- Socket.IO events or room behavior affected: Listens for `BE_CARD_NOTIFICATIONS_UPDATED`; events are emitted by the API to authenticated user rooms. Existing `BE_BOARD_UPDATED` board refresh remains unchanged.

### Configuration and deployment

- New or changed environment variables: None.
- Vercel configuration changed: No.
- Deployment order or cache considerations: Deploy API PR #37 first, then this Web PR. Normal Vercel asset cache busting applies.

## Verification

- [x] `yarn lint`
- [x] `yarn test`
- [x] `yarn build`
- [ ] Relevant Playwright E2E tests
- [ ] Manual verification in a production-like browser

### Test evidence

```text
Command: yarn lint
Result: passed

Command: yarn test
Result: 15 passed, 0 failed

Command: yarn build
Result: production build passed; existing large-chunk warning remains (main JS approximately 2.1 MB)

Command: Playwright test discovery
Result: 9 valid scenarios discovered, including 4 Phase 1 card workflows

Command: full Playwright execution
Result: blocked before application setup by querySrv ETIMEOUT for the configured MongoDB Atlas test URI
```

### Scenarios verified

- [x] Happy path
- [x] Loading, empty, and error states
- [x] Authentication and authorization boundaries
- [x] Refresh and direct-navigation behavior
- [x] Realtime update and reconnect behavior, when applicable
- [x] Responsive layout and keyboard interaction, when applicable

The checked scenarios are covered by unit/E2E definitions; the browser suite must be rerun with a reachable disposable MongoDB replica set before marking the PR ready for review.

## Risk and rollback

- Risk level: Medium
- Main risks: UI/API version mismatch during deployment, notification polling load, attachment failures from Cloudinary, and card modal state becoming stale during concurrent edits.
- Monitoring or validation after deployment: Verify Vercel console/network errors, assignment notification badge refresh, direct card links, attachment upload/delete, archive/restore, and viewer read-only behavior against the deployed API.
- Rollback plan: Revert this PR and redeploy the previous Vercel build; if necessary, roll back API PR #37 after the Web rollback.

## Final checklist

- [x] The PR has a focused scope and a clear title.
- [x] No secrets, tokens, credentials, or production data are included.
- [x] UI text, errors, and console output are intentional.
- [x] Accessibility and responsive behavior were considered.
- [x] Tests cover the regression or new behavior.
- [x] Documentation and environment examples are updated when required.
- [x] Breaking changes and required deployment order are clearly identified.

## Reviewer notes

Focus review on card-detail update payloads, permission-gated controls, archive/copy/move state refresh, mixed deadline value handling in `cardPhase1`, and notification listener/poll cleanup. Rerun Playwright against a reachable disposable MongoDB replica set before changing this PR from draft to ready.