### PR TITLE
fix: preserve attachment filenames and clarify activity messages

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -197,6 +197,14 @@ export const deleteCardAttachmentAPI = async (cardId, attachmentId) => {
   return response.data
 }
 
+export const downloadCardAttachmentAPI = async (cardId, attachmentId) => {
+  const response = await authorizedAxiosInstance.get(
+    `${API_ROOT}/v1/cards/${cardId}/attachments/${attachmentId}/download`,
+    { responseType: 'blob' }
+  )
+  return response.data
+}
+
 export const fetchArchivedCardsAPI = async (boardId) => {
   const response = await authorizedAxiosInstance.get(
     `${API_ROOT}/v1/cards/archived/board/${boardId}`

--- a/src/components/Modal/ActiveCard/ActiveCard.jsx
+++ b/src/components/Modal/ActiveCard/ActiveCard.jsx
@@ -40,11 +40,13 @@ import {
 import {
   copyCardAPI,
   deleteCardAttachmentAPI,
+  downloadCardAttachmentAPI,
   moveCardAPI,
   setCardArchivedAPI,
   updateCardDetailsAPI,
   uploadCardAttachmentAPI
 } from '~/apis'
+import { saveBlobAsFile } from '~/utils/fileDownloads'
 import {
   selectCurrentActiveBoard,
   updateCardInBoard
@@ -162,6 +164,14 @@ function ActiveCard() {
     const updatedCard = await deleteCardAttachmentAPI(activeCard._id, attachmentId)
     dispatch(updateCurrentActiveCard(updatedCard))
     dispatch(updateCardInBoard(updatedCard))
+  }
+
+  const onDownloadAttachment = async (attachment) => {
+    const blob = await downloadCardAttachmentAPI(
+      activeCard._id,
+      attachment._id
+    )
+    saveBlobAsFile(blob, attachment.name)
   }
 
   const selectedColumnId = actionTargetColumnId || activeCard?.columnId || ''
@@ -340,6 +350,7 @@ function ActiveCard() {
               canEdit={canEdit}
               onUpload={onUploadAttachment}
               onDelete={onDeleteAttachment}
+              onDownload={onDownloadAttachment}
             />
 
             <Box sx={{ mb: 3 }}>

--- a/src/components/Modal/ActiveCard/CardAttachments.jsx
+++ b/src/components/Modal/ActiveCard/CardAttachments.jsx
@@ -13,7 +13,13 @@ import VisuallyHiddenInput from '~/components/Form/VisuallyHiddenInput'
 import { attachmentFileValidator } from '~/utils/validators'
 import { toast } from 'react-toastify'
 
-function CardAttachments({ attachments = [], canEdit, onUpload, onDelete }) {
+function CardAttachments({
+  attachments = [],
+  canEdit,
+  onUpload,
+  onDelete,
+  onDownload
+}) {
   const handleUpload = async (event) => {
     const file = event.target.files?.[0]
     const error = attachmentFileValidator(file)
@@ -59,7 +65,15 @@ function CardAttachments({ attachments = [], canEdit, onUpload, onDelete }) {
             >
               <ListItemText
                 primary={
-                  <Link href={attachment.url} target='_blank' rel='noreferrer'>
+                  <Link
+                    component='button'
+                    type='button'
+                    onClick={() => toast.promise(
+                      onDownload(attachment),
+                      { pending: `Downloading ${attachment.name}...` }
+                    )}
+                    sx={{ textAlign: 'left' }}
+                  >
                     {attachment.name}
                   </Link>
                 }

--- a/src/pages/Boards/BoardBar/BoardActivityDrawer.jsx
+++ b/src/pages/Boards/BoardBar/BoardActivityDrawer.jsx
@@ -9,24 +9,7 @@ import Typography from '@mui/material/Typography'
 import HistoryIcon from '@mui/icons-material/History'
 import moment from 'moment'
 import { fetchBoardActivitiesAPI } from '~/apis'
-
-const ACTION_LABELS = {
-  BOARD_CREATED: 'created the board',
-  BOARD_UPDATED: 'updated the board',
-  BOARD_MEMBER_ROLE_CHANGED: 'changed a member role',
-  COLUMN_CREATED: 'created a column',
-  COLUMN_UPDATED: 'updated a column',
-  COLUMN_DELETED: 'deleted a column',
-  CARD_CREATED: 'created a card',
-  CARD_UPDATED: 'updated a card',
-  CARD_MOVED: 'moved a card',
-  CARD_COMMENTED: 'commented on a card',
-  CARD_MEMBER_ADDED: 'assigned a card member',
-  CARD_MEMBER_REMOVED: 'removed a card member',
-  INVITATION_CREATED: 'invited a board member',
-  INVITATION_ACCEPTED: 'accepted a board invitation',
-  INVITATION_REJECTED: 'rejected a board invitation'
-}
+import { formatActivityMessage } from '~/utils/activityMessages'
 
 function BoardActivityDrawer({ boardId }) {
   const [open, setOpen] = useState(false)
@@ -115,7 +98,7 @@ function BoardActivityDrawer({ boardId }) {
                   <strong>
                     {activity.actor?.displayName || 'Former member'}
                   </strong>{' '}
-                  {ACTION_LABELS[activity.action] || activity.action}
+                  {formatActivityMessage(activity)}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>
                   {moment(activity.createdAt).format('llll')}

--- a/src/utils/activityMessages.js
+++ b/src/utils/activityMessages.js
@@ -1,0 +1,118 @@
+const FIELD_LABELS = {
+  title: 'title',
+  description: 'description',
+  priority: 'priority',
+  startDate: 'start date',
+  dueDate: 'due date',
+  completedAt: 'completion status',
+  labels: 'labels',
+  checklist: 'checklist',
+  watcherIds: 'watchers',
+  cover: 'cover',
+  columnOrderIds: 'column order',
+  cardOrderIds: 'card order'
+}
+
+const quote = (value) => value ? `“${value}”` : ''
+
+const getEntityTitle = (activity) =>
+  activity.metadata?.entityTitle || activity.entityTitle
+
+const getTargetName = (activity) =>
+  activity.targetUser?.displayName ||
+  activity.targetUser?.userName ||
+  'a board member'
+
+const describeFields = (fields = []) => {
+  const labels = fields.map((field) => FIELD_LABELS[field] || field)
+  if (!labels.length) return 'card details'
+  if (labels.length === 1) return labels[0]
+  return `${labels.slice(0, -1).join(', ')} and ${labels.at(-1)}`
+}
+
+const cardName = (activity) =>
+  getEntityTitle(activity)
+    ? `card ${quote(getEntityTitle(activity))}`
+    : 'a card'
+
+const columnName = (activity) =>
+  getEntityTitle(activity)
+    ? `column ${quote(getEntityTitle(activity))}`
+    : 'a column'
+
+const boardName = (activity) =>
+  getEntityTitle(activity)
+    ? `board ${quote(getEntityTitle(activity))}`
+    : 'the board'
+
+const attachmentName = (activity) =>
+  activity.metadata?.name
+    ? `attachment ${quote(activity.metadata.name)}`
+    : 'an attachment'
+
+const FORMATTERS = {
+  BOARD_CREATED: (activity) => `created ${boardName(activity)}`,
+  BOARD_UPDATED: (activity) => activity.metadata?.fields?.includes('columnOrderIds')
+    ? `reordered columns on ${boardName(activity)}`
+    : `updated ${boardName(activity)}`,
+  BOARD_MEMBER_ROLE_CHANGED: (activity) =>
+    `changed ${getTargetName(activity)}'s role to ${activity.metadata?.role || 'a new role'}`,
+  COLUMN_CREATED: (activity) => `created ${columnName(activity)}`,
+  COLUMN_UPDATED: (activity) => activity.metadata?.fields?.includes('cardOrderIds')
+    ? `reordered cards in ${columnName(activity)}`
+    : `updated ${columnName(activity)}`,
+  COLUMN_DELETED: (activity) => `deleted ${columnName(activity)}`,
+  CARD_CREATED: (activity) => `created ${cardName(activity)}`,
+  CARD_UPDATED: (activity) =>
+    `updated ${describeFields(activity.metadata?.fields)} on ${cardName(activity)}`,
+  CARD_MOVED: (activity) => {
+    const destination = activity.metadata?.toColumnTitle
+      ? `column ${quote(activity.metadata.toColumnTitle)}`
+      : 'another column'
+    return `moved ${cardName(activity)} to ${destination}`
+  },
+  CARD_COMMENTED: (activity) => `commented on ${cardName(activity)}`,
+  CARD_COMMENT_EDITED: (activity) => `edited a comment on ${cardName(activity)}`,
+  CARD_COMMENT_DELETED: (activity) => `deleted a comment from ${cardName(activity)}`,
+  CARD_COMMENT_REACTED: (activity) => {
+    if (!activity.metadata?.reactionAction) {
+      return `reacted to a comment in ${cardName(activity)}`
+    }
+    const reaction = activity.metadata?.emoji
+      ? ` ${activity.metadata.emoji}`
+      : ''
+    const verb = activity.metadata?.reactionAction === 'REMOVED'
+      ? 'removed'
+      : 'added'
+    return `${verb}${reaction} reaction on a comment in ${cardName(activity)}`
+  },
+  CARD_MEMBER_ADDED: (activity) =>
+    `assigned ${getTargetName(activity)} to ${cardName(activity)}`,
+  CARD_MEMBER_REMOVED: (activity) =>
+    `removed ${getTargetName(activity)} from ${cardName(activity)}`,
+  CARD_DUE_DATE_CHANGED: (activity) =>
+    `changed the due date of ${cardName(activity)}`,
+  CARD_CHECKLIST_COMPLETED: (activity) =>
+    `completed the checklist on ${cardName(activity)}`,
+  CARD_COMPLETED: (activity) => `marked ${cardName(activity)} as completed`,
+  CARD_ARCHIVED: (activity) => `archived ${cardName(activity)}`,
+  CARD_RESTORED: (activity) => `restored ${cardName(activity)}`,
+  CARD_COPIED: (activity) => `copied ${cardName(activity)}`,
+  CARD_ATTACHMENT_ADDED: (activity) =>
+    `added ${attachmentName(activity)} to ${cardName(activity)}`,
+  CARD_ATTACHMENT_REMOVED: (activity) =>
+    `removed ${attachmentName(activity)} from ${cardName(activity)}`,
+  INVITATION_CREATED: (activity) =>
+    `invited ${getTargetName(activity)} to the board`,
+  INVITATION_ACCEPTED: () => 'accepted a board invitation',
+  INVITATION_REJECTED: () => 'rejected a board invitation'
+}
+
+export const SUPPORTED_ACTIVITY_ACTIONS = Object.freeze(
+  Object.keys(FORMATTERS)
+)
+
+export const formatActivityMessage = (activity) => {
+  const formatter = FORMATTERS[activity.action]
+  return formatter ? formatter(activity) : 'performed a board activity'
+}

--- a/src/utils/fileDownloads.js
+++ b/src/utils/fileDownloads.js
@@ -1,0 +1,34 @@
+export const normalizeDownloadFileName = (fileName) => {
+  const baseName = String(fileName || '')
+    .split(/[\\/]/)
+    .pop()
+  const normalized = [...baseName]
+    .filter((character) => {
+      const code = character.charCodeAt(0)
+      return code >= 32 && code !== 127
+    })
+    .join('')
+    .trim()
+
+  return normalized || 'attachment'
+}
+
+export const saveBlobAsFile = (
+  blob,
+  fileName,
+  {
+    documentRef = document,
+    urlApi = URL,
+    schedule = setTimeout
+  } = {}
+) => {
+  const objectUrl = urlApi.createObjectURL(blob)
+  const anchor = documentRef.createElement('a')
+  anchor.href = objectUrl
+  anchor.download = normalizeDownloadFileName(fileName)
+  anchor.style.display = 'none'
+  documentRef.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  schedule(() => urlApi.revokeObjectURL(objectUrl), 0)
+}

--- a/tests/activityMessages.test.js
+++ b/tests/activityMessages.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  formatActivityMessage,
+  SUPPORTED_ACTIVITY_ACTIONS
+} from '../src/utils/activityMessages.js'
+
+test('formats every supported activity without exposing internal enum names', () => {
+  for (const action of SUPPORTED_ACTIVITY_ACTIONS) {
+    const message = formatActivityMessage({
+      action,
+      entityTitle: 'Release card',
+      targetUser: { displayName: 'Alex' },
+      metadata: {
+        fields: ['priority', 'dueDate'],
+        role: 'ADMIN',
+        name: 'release-notes.pdf',
+        emoji: '👍',
+        reactionAction: 'ADDED'
+      }
+    })
+
+    assert.equal(message.includes(action), false, action)
+    assert.equal(message.includes('_'), false, action)
+    assert.equal(message.length > 8, true, action)
+  }
+})
+
+test('describes comment reactions with the emoji and card title', () => {
+  assert.equal(
+    formatActivityMessage({
+      action: 'CARD_COMMENT_REACTED',
+      entityTitle: 'Release card',
+      metadata: { emoji: '👍', reactionAction: 'ADDED' }
+    }),
+    'added 👍 reaction on a comment in card “Release card”'
+  )
+  assert.equal(
+    formatActivityMessage({
+      action: 'CARD_COMMENT_REACTED',
+      entityTitle: 'Release card',
+      metadata: { emoji: '👍', reactionAction: 'REMOVED' }
+    }),
+    'removed 👍 reaction on a comment in card “Release card”'
+  )
+  assert.equal(
+    formatActivityMessage({
+      action: 'CARD_COMMENT_REACTED',
+      entityTitle: 'Release card',
+      metadata: {}
+    }),
+    'reacted to a comment in card “Release card”'
+  )
+})
+
+test('uses activity metadata when a deleted entity no longer exists', () => {
+  assert.equal(
+    formatActivityMessage({
+      action: 'COLUMN_DELETED',
+      metadata: { entityTitle: 'Deprecated work' }
+    }),
+    'deleted column “Deprecated work”'
+  )
+})
+
+test('identifies the destination column when a card is moved', () => {
+  assert.equal(
+    formatActivityMessage({
+      action: 'CARD_MOVED',
+      entityTitle: 'Release card',
+      metadata: { toColumnTitle: 'Ready for QA' }
+    }),
+    'moved card “Release card” to column “Ready for QA”'
+  )
+})
+
+test('never exposes an unknown backend action', () => {
+  assert.equal(
+    formatActivityMessage({ action: 'UNRECOGNIZED_INTERNAL_ACTION' }),
+    'performed a board activity'
+  )
+})

--- a/tests/fileDownloads.test.js
+++ b/tests/fileDownloads.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  normalizeDownloadFileName,
+  saveBlobAsFile
+} from '../src/utils/fileDownloads.js'
+
+test('preserves the attachment extension while removing unsafe path data', () => {
+  assert.equal(
+    normalizeDownloadFileName('C:\\fakepath\\release notes.pdf'),
+    'release notes.pdf'
+  )
+  assert.equal(normalizeDownloadFileName('../../report.xlsx'), 'report.xlsx')
+  assert.equal(normalizeDownloadFileName('\u0000'), 'attachment')
+})
+
+test('downloads a blob using the normalized original filename', () => {
+  const events = []
+  const anchor = {
+    style: {},
+    click: () => events.push('clicked'),
+    remove: () => events.push('removed')
+  }
+  const documentRef = {
+    createElement: (tagName) => {
+      assert.equal(tagName, 'a')
+      return anchor
+    },
+    body: {
+      appendChild: (element) => {
+        assert.equal(element, anchor)
+        events.push('appended')
+      }
+    }
+  }
+  const urlApi = {
+    createObjectURL: () => 'blob:attachment',
+    revokeObjectURL: (url) => events.push(`revoked:${url}`)
+  }
+
+  saveBlobAsFile({}, '../release.zip', {
+    documentRef,
+    urlApi,
+    schedule: (callback) => callback()
+  })
+
+  assert.equal(anchor.href, 'blob:attachment')
+  assert.equal(anchor.download, 'release.zip')
+  assert.deepEqual(events, [
+    'appended',
+    'clicked',
+    'removed',
+    'revoked:blob:attachment'
+  ])
+})


### PR DESCRIPTION
## Summary

This PR fixes attachment download filenames and replaces raw activity action enums with clear, user-facing messages.

## Root cause

- The UI opened cross-origin Cloudinary URLs directly, so the browser did not consistently receive the original attachment filename or extension.
- The activity drawer only mapped a subset of actions and fell back to rendering raw enum values such as `CARD_COMMENT_REACTED`.
- Existing messages did not use card, column, attachment, reaction, or target-user details returned by the API.

## Changes

### Attachment downloads

- Download attachments through the authenticated API endpoint as blobs.
- Save each blob with the normalized original attachment name.
- Preserve file extensions while removing unsafe path and control characters.
- Revoke temporary browser object URLs after the download starts.
- Keep downloads available to read-only board members.

### Activity messages

- Add a centralized formatter covering every currently supported activity action.
- Include card, column, board, attachment, member, destination-column, field, and reaction details where available.
- Display whether an emoji reaction was added or removed.
- Use a neutral message for legacy reaction records that lack add/remove metadata.
- Never expose unknown backend enum identifiers to users.

### Tests

- Verify filename normalization and extension preservation.
- Verify the blob download lifecycle and original download name.
- Verify all supported activities produce readable messages without enum leakage.
- Cover reaction add/remove/legacy cases, deleted entities, moved-card destinations, and unknown actions.

## Impact

Users receive attachments with the correct filename and extension. The board activity drawer now displays understandable event descriptions instead of internal action constants.

## Validation

- `yarn lint`
- `yarn test`: 22 passed, 0 failed
- `yarn build`: production build passed

The existing Vite chunk-size warning remains unchanged and is outside the scope of this fix.

## Related API change

- https://github.com/dhoangvu1811/Trello-Api/pull/38